### PR TITLE
Push git tag to docker hub

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,5 +5,5 @@ build:
   stage: build
   script:
     - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA -f Dockerfile.armhf .
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA $CI_REGISTRY_IMAGE:armhf
-    - docker push $CI_REGISTRY_IMAGE:armhf
+    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA $CI_REGISTRY_IMAGE:${CI_COMMIT_TAG}-armhf
+    - docker push $CI_REGISTRY_IMAGE:${CI_COMMIT_TAG}-armhf


### PR DESCRIPTION
First of all, thanks for maintaining the docker image so far!

I'm running your images on kubernetes and am encountering the problem, that the images are only tagged with `latest` or `armhf` on docker hub. In case your CI pushes a new docker image to docker hub, the images will be overwritten and tagged with `latest` or `armhf` again. It's currently not possible to target a specific version of the image (e.g. `0.13.0`), only the latest version.
This leads into problems, as kubernetes would always pull the latest version, without me being able to control that properly.

I propose to always tag the newly built images with the latest git tag. E.g. `nico640/docker-unms:1.0.3-armhf`.
What do you think about that? My proposal isn't necessarily complete, as I don't fully understand your current gitlab CI pipeline.
Thanks