### PR TITLE
Bump lua_nginx_module to version supporting arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN grep -lR "nginx:nginx" /usr/src/ucrm/ | xargs sed -i 's/nginx:nginx/unms:unm
 ENV NGINX_UID=1000 \
     NGINX_VERSION=nginx-1.14.2 \
     LUAJIT_VERSION=2.1.0-beta3 \
-    LUA_NGINX_VERSION=0.10.13 \
+    LUA_NGINX_VERSION=0.10.14 \
     PHP_VERSION=php-7.3.17
 
 RUN set -x \


### PR DESCRIPTION
Since arm64 support was added in openresty/lua-nginx-module#1379 in `0.10.14`, I needed to bump it from `0.10.13`. 
However, I haven't tested the changes for amd64 or armhf and therefore don't really know what the implications are.