### PR TITLE
allow setting nginx ports from environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -278,7 +278,9 @@ WORKDIR /home/app/unms
 ENV PATH=$PATH:/home/app/unms/node_modules/.bin:/opt/rabbitmq/sbin:/usr/local/openresty/bin \
     QUIET_MODE=0 \
     PUBLIC_HTTPS_PORT=443 \
-    PUBLIC_WS_PORT=443
+    PUBLIC_WS_PORT=443 \
+    HTTP_PORT=80 \
+    HTTPS_PORT=443
 
 EXPOSE 80 443 2055/udp
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The parameters are split into two halves, separated by a colon, the left hand si
 * `-e DEMO=false` - Enable UISP demo mode
 * `-e PUBLIC_HTTPS_PORT=443` - This should match the HTTPS port your are exposing to on the docker host
 * `-e PUBLIC_WS_PORT=443` - This should match the HTTPS port your are exposing to on the docker host
+* `-e HTTPS_PORT=443` - Sets the HTTPS port the container's webserver is listening on
+* `-e HTTP_PORT=80` - Set ths HTTP port the container's webserver is listening on
 * `-e SSL_CERT=` - Filename of custom SSL certificate in /config/usercert/
 * `-e SSL_CERT_KEY=` - Filename of custom SSL key in /config/usercert/
 * `-e PUID=911` - User ID of the container user

--- a/root/etc/services.d/nginx/run
+++ b/root/etc/services.d/nginx/run
@@ -1,7 +1,5 @@
 #!/command/with-contenv sh
 
-export HTTP_PORT=80
-export HTTPS_PORT=443
 export UNMS_HTTP_PORT=8081
 export UNMS_WS_PORT=8082
 export UNMS_WS_SHELL_PORT=8083


### PR DESCRIPTION
Allowing to move the internal web server ports makes it easier to run a custom reverse proxy within the same network namespace (e.g. pods). 